### PR TITLE
boto3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-boto3<1.38
+boto3<1.37
 python-dotenv
 pytimeparse
 humanfriendly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-boto3<1.37
+boto3<1.36
 python-dotenv
 pytimeparse
 humanfriendly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-boto3
+boto3<1.38
 python-dotenv
 pytimeparse
 humanfriendly

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -158,7 +158,7 @@ class TestS3Put(unittest.TestCase):
         with Stubber(s3if) as stubber:
             stubber.add_response(
                 "put_object", {},
-                {"Body": ANY, "Bucket": "bucket123", "Key": "key123", "ChecksumAlgorithm": "CRC32"})
+                {"Body": ANY, "Bucket": "bucket123", "Key": "key123"})
             ps = S3PutStream(rd, s3if, bucket="bucket123", key="key123", bufsize=1024)
             for _ in ps.gen():
                 pass


### PR DESCRIPTION
```
botocore.exceptions.ClientError: An error occurred (InvalidArgument) when calling the PutObject operation: Unsupported header 'x-amz-sdk-checksum-algorithm' received for this API call.
```