### PR TITLE
Fix update-deps.yml: install ext system libs + sync optional extras

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -12,7 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - name: prepare
+      run: "sudo apt update && sudo apt install -y libsnappy-dev liblzo2-dev"
     - uses: wtnb75/actions/python@v1
+      with:
+        extra-args: "--extra ext --extra test"
     - uses: wtnb75/actions/pyupdate@v1
       with:
         test-args: "-xs"


### PR DESCRIPTION
## Summary
`update-deps.yml` has been failing on every run (2026-07-31, 2026-08-02). Its `python` composite step had no `extra-args` at all — unlike `branch.yml`/`main.yml`, which install `libsnappy-dev`/`liblzo2-dev` and sync `--extra ext --extra test` before running the test suite.

Reproduced locally with a bare `uv sync` (no extras, matching what `update-deps.yml` was actually doing):
- without `httpx` (the `test` extra), `starlette.testclient` hard-fails at import time: `RuntimeError: The starlette.testclient module requires the httpx2 package to be installed.` (httpx is deprecated upstream in favor of httpx2, but still works with just a warning when present — not touching that migration here, out of scope for this fix)
- without `PyYAML` (the `ext` extra), `tests/test_ible.py::test_convert_sh2json` fails with `UnboundLocalError` (`log2s3/main.py`'s `try_read()` references `yaml.error` in an `except` clause after a caught `ImportError`, so `yaml` was never bound — pre-existing, not introduced here)

Added the same `prepare` (apt install) + `extra-args` steps `branch.yml`/`main.yml` already have.

## Test plan
- [x] Reproduced both failures locally with `uv sync` (no extras)
- [x] Re-dispatched `update-deps.yml` on this branch — green: https://github.com/wtnb75/log2s3/actions/runs/30735610410

🤖 Generated with [Claude Code](https://claude.com/claude-code)