### PR TITLE
tag.yml: fix version.py quote style to match ruff format

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,8 @@ jobs:
     - name: prepare
       run: "sudo apt update && sudo apt install -y libsnappy-dev liblzo2-dev"
     - name: versioning
-      run: "echo \"VERSION = '${GITHUB_REF##*/v}'\" > log2s3/version.py"
+      run: |
+        echo "VERSION = \"${GITHUB_REF##*/v}\"" > log2s3/version.py
     - uses: wtnb75/actions/python@v1
       with:
         extra-args: "--extra ext --extra test"


### PR DESCRIPTION
## Background
Same bug as wtnb75/pstyle#11 (which broke a real `v0.2.1` tag release): `tag.yml`'s `versioning` step writes `VERSION = '$VERSION'` (single-quoted), but the following `wtnb75/actions/ruff@v1` step's `ruff format --check` defaults to double-quoted strings and fails on the file just generated. This repo hasn't hit it yet only because its `tag.yml` hasn't been exercised by a real tag recently.

## Fix
Same fix as pstyle: generate the version file with double quotes.

## Verification
Reproduced the exact shell command locally and confirmed `ruff format --check` passes on the output. On real CI (branch push), the `ruff` step itself passed cleanly on two separate runs: https://github.com/wtnb75/log2s3/actions/runs/30813499012 (both the original run and a rerun stalled afterward on an unrelated `cache pip` step for 10+ minutes each time — a GitHub Actions cache-service issue unrelated to this change; every step this fix touches completed successfully both times before that point).

Full `tag.yml` verification requires an actual tag push, left for your next real release.